### PR TITLE
i960Kx startup code documentation

### DIFF
--- a/include.S
+++ b/include.S
@@ -2186,8 +2186,8 @@
    .set  list_motions_ram,0x5A0004
    .globl instruction_thing
    .set instruction_thing,0x5FF000 
-   .globl instruction_thing2
-   .set instruction_thing2,0x5FF410
+   .globl prcb_ram
+   .set prcb_ram,0x5FF410
    .globl   GEO_START
    .set  GEO_START,0x800000
    .globl   GEO_PROGRAM_START

--- a/include.S
+++ b/include.S
@@ -2184,8 +2184,8 @@
    .set  num_motions_ram,0x5A0000
    .globl   list_motions_ram
    .set  list_motions_ram,0x5A0004
-   .globl instruction_thing
-   .set instruction_thing,0x5FF000 
+   .globl intr_ram
+   .set intr_ram,0x5FF000 
    .globl prcb_ram
    .set prcb_ram,0x5FF410
    .globl   GEO_START


### PR DESCRIPTION
Looking through the code I fixed names and added a bunch of comments about what things are. I focused specifically around the initialization of the i960KB processor. What's strange is that the devs at Sega obviously had the Kx reference manual sitting around but then at some point decided to go their own path. This is especially true in the fact that they manually setup the arithmetic and process controls. 

I also cleaned some names because the code they point to is a direct rip from the reference manual (move_data comes to mind specifically). 

The code is the same, but the names are better defined. 